### PR TITLE
Resign child first responder when removing a view

### DIFF
--- a/Sources/SwiftTUI/Controls/Control.swift
+++ b/Sources/SwiftTUI/Controls/Control.swift
@@ -24,7 +24,7 @@ class Control: LayerDrawing {
     }
 
     func removeSubview(at index: Int) {
-        if children[index].isFirstResponder {
+        if children[index].isFirstResponder || root.window?.firstResponder?.isDescendant(of: children[index]) == true {
             root.window?.firstResponder?.resignFirstResponder()
             root.window?.firstResponder = selectableElement(above: index) ?? selectableElement(below: index)
             root.window?.firstResponder?.becomeFirstResponder()
@@ -36,6 +36,11 @@ class Control: LayerDrawing {
         for i in index ..< children.count {
             children[i].index = i
         }
+    }
+
+    func isDescendant(of control: Control) -> Bool {
+        guard let parent else { return false }
+        return control === parent || parent.isDescendant(of: control)
     }
 
     func makeLayer() -> Layer {


### PR DESCRIPTION
Fixes #14.

It is implemented in a breadth–first search fashion using a mutable array as queue.

In master the issue can be reproduced with this code snippet:

```
struct ContentView: View {
    @State var visible = true

    var body: some View {
        VStack {
            Button("toggle 1", action: { self.visible = !visible })
            if visible {
                HStack {
                    Button("toggle 2", action: { self.visible = !visible })
                    Text("visible")
                }
            }
        }
    }
}
```

**How to reproduce:** Press "toggle 2" button.

**Expected result:** "toggle 2" button and "visible" text disappear; "toggle 1" becomes first responder.

**Actual result:** "toggle 2" button and "visible" text disappear; "toggle 1" is not the first responder (there is not any _visible_ first responder).