### PR TITLE
Model Cell's attributes with AttributeContainer

### DIFF
--- a/Examples/Flags/Package.swift
+++ b/Examples/Flags/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Flags",
     platforms: [
-        .macOS(.v11)
+        .macOS(.v12)
     ],
     dependencies: [
         .package(path: "../../")

--- a/Examples/Numbers/Package.swift
+++ b/Examples/Numbers/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Numbers",
     platforms: [
-        .macOS(.v11)
+        .macOS(.v12)
     ],
     dependencies: [
         .package(path: "../../")

--- a/Examples/Numbers/Sources/Numbers/ContentView.swift
+++ b/Examples/Numbers/Sources/Numbers/ContentView.swift
@@ -1,7 +1,10 @@
+import Foundation
 import SwiftTUI
 
 struct ContentView: View {
     @State var counter = 1
+
+    let numberAttributes = AttributeContainer().underlineStyle(Text.LineStyle(pattern: .solid))
 
     var body: some View {
         VStack {
@@ -10,7 +13,7 @@ struct ContentView: View {
                 Button("Remove number") { counter -= 1 }
             }
             ForEach(1 ... counter, id: \.self) { i in
-                Text("Number \(i)")
+                Text(AttributedString("Number ") + AttributedString("\(i)", attributes: numberAttributes))
             }
             .border()
         }

--- a/Examples/ToDoList/Package.swift
+++ b/Examples/ToDoList/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "ToDoList",
     platforms: [
-        .macOS(.v11)
+        .macOS(.v12)
     ],
     dependencies: [
         .package(path: "../../")

--- a/Examples/ToDoList/Sources/ToDoList/ToDoView.swift
+++ b/Examples/ToDoList/Sources/ToDoList/ToDoView.swift
@@ -11,10 +11,11 @@ struct ToDoView: View {
         HStack {
             if deleting {
                 Text("[x]")
+                Text(toDo.text).strikethrough()
             } else {
                 Button("[ ]", action: delete)
+                Text(toDo.text)
             }
-            Text(toDo.text)
         }
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftTUI",
     platforms: [
-        .macOS(.v11)
+        .macOS(.v12)
     ],
     products: [
         .library(

--- a/Sources/SwiftTUI/Drawing/AttributeScopes+SwiftTUIAttributes.swift
+++ b/Sources/SwiftTUI/Drawing/AttributeScopes+SwiftTUIAttributes.swift
@@ -11,6 +11,9 @@ extension AttributeScopes {
         public typealias DecodingConfiguration = AttributeScopeCodableConfiguration
         public typealias EncodingConfiguration = AttributeScopeCodableConfiguration
 
+        public let strikethroughStyle: StrikethroughStyleAttribute = StrikethroughStyleAttribute()
+        public let underlineStyle: UnderlineStyleAttribute = UnderlineStyleAttribute()
+
         let inverted: InvertedAttribute = InvertedAttribute()
     }
 }
@@ -31,6 +34,16 @@ extension AttributeScopes.SwiftTUIAttributes {
         public static let name = "Font"
     }
     
+    public struct StrikethroughStyleAttribute: AttributedStringKey {
+        public typealias Value = Text.LineStyle
+        public static let name = "StrikethroughStyle"
+    }
+
+    public struct UnderlineStyleAttribute: AttributedStringKey {
+        public typealias Value = Text.LineStyle
+        public static let name = "UnderlineStyle"
+    }
+
     struct InvertedAttribute: AttributedStringKey {
         typealias Value = Bool
         static let name = "Inverted"

--- a/Sources/SwiftTUI/Drawing/AttributeScopes+SwiftTUIAttributes.swift
+++ b/Sources/SwiftTUI/Drawing/AttributeScopes+SwiftTUIAttributes.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+extension AttributeScopes {
+    /// Attribute scopes that SwiftTUI defines.
+    public struct SwiftTUIAttributes: AttributeScope {
+        public let backgroundColor: BackgroundColorAttribute = BackgroundColorAttribute()
+        public let foregroundColor: ForegroundColorAttribute = ForegroundColorAttribute()
+
+        public let font: FontAttribute = FontAttribute()
+    
+        public typealias DecodingConfiguration = AttributeScopeCodableConfiguration
+        public typealias EncodingConfiguration = AttributeScopeCodableConfiguration
+
+        let inverted: InvertedAttribute = InvertedAttribute()
+    }
+}
+
+extension AttributeScopes.SwiftTUIAttributes {
+    public struct BackgroundColorAttribute: AttributedStringKey {
+        public typealias Value = Color
+        public static let name = "BackgroundColor"
+    }
+
+    public struct ForegroundColorAttribute: AttributedStringKey {
+        public typealias Value = Color
+        public static let name = "ForegroundColor"
+    }
+
+    public struct FontAttribute: AttributedStringKey {
+        public typealias Value = Font
+        public static let name = "Font"
+    }
+    
+    struct InvertedAttribute: AttributedStringKey {
+        typealias Value = Bool
+        static let name = "Inverted"
+    }
+}
+
+public extension AttributeDynamicLookup {
+    /// Adds dynamic member lookup of SwiftTUI attributes.
+  subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeScopes.SwiftTUIAttributes, T>) -> T {
+    self[T.self]
+  }
+}

--- a/Sources/SwiftTUI/Drawing/Cell.swift
+++ b/Sources/SwiftTUI/Drawing/Cell.swift
@@ -2,21 +2,10 @@ import Foundation
 
 struct Cell: Equatable {
     var char: Character
-    var foregroundColor: Color
+    var attributes: AttributeContainer
 
-    /// When this is nil, it does not mean the default background color.
-    /// Rather, it means that the background color from the content below
-    /// is used.
-    var backgroundColor: Color?
-
-    var font: Font
-    var inverted: Bool
-
-    init(char: Character, foregroundColor: Color = .default, backgroundColor: Color? = nil, font: Font = Font(), inverted: Bool = false) {
+    init(char: Character, attributes: AttributeContainer = AttributeContainer()) {
         self.char = char
-        self.foregroundColor = foregroundColor
-        self.backgroundColor = backgroundColor
-        self.font = font
-        self.inverted = inverted
+        self.attributes = attributes
     }
 }

--- a/Sources/SwiftTUI/Drawing/Color.swift
+++ b/Sources/SwiftTUI/Drawing/Color.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Color: Equatable {
+public struct Color: Hashable {
     let foregroundCode: Int
     let backgroundCode: Int
 

--- a/Sources/SwiftTUI/Drawing/Rendering/Layer.swift
+++ b/Sources/SwiftTUI/Drawing/Rendering/Layer.swift
@@ -51,10 +51,11 @@ class Layer {
 
     func cell(at position: Position) -> Cell? {
         var char: Character? = nil
-        var inverted: Bool = false
-        var foregroundColor: Color? = nil
-        var backgroundColor: Color? = nil
-        var font: Font? = nil
+        var attributes: AttributeContainer = AttributeContainer()
+
+        // When attributes.backgroundColor is nil, it does not mean the default background color.
+        // Rather, it means that the background color from the content below
+        // is used.
 
         // Draw children
         for child in children.reversed() {
@@ -63,12 +64,10 @@ class Layer {
             if let cell = child.cell(at: position) {
                 if char == nil {
                     char = cell.char
-                    inverted = cell.inverted
-                    foregroundColor = cell.foregroundColor
-                    font = cell.font
+                    attributes = cell.attributes
                 }
-                if let color = cell.backgroundColor {
-                    backgroundColor = color
+                if let color = cell.attributes.backgroundColor {
+                    attributes = attributes.backgroundColor(color)
                     break
                 }
             }
@@ -78,16 +77,14 @@ class Layer {
         if let cell = content?.cell(at: position) {
             if char == nil {
                 char = cell.char
-                inverted = cell.inverted
-                foregroundColor = cell.foregroundColor
-                font = cell.font
+                attributes = cell.attributes
             }
-            if backgroundColor == nil {
-                backgroundColor = cell.backgroundColor
+            if attributes.backgroundColor == nil, let backgroundColor = cell.attributes.backgroundColor {
+                attributes = attributes.backgroundColor(backgroundColor)
             }
         }
 
-        return char.map { Cell(char: $0, foregroundColor: foregroundColor ?? .default, backgroundColor: backgroundColor, font: font ?? Font(), inverted: inverted) }
+        return char.map { Cell(char: $0, attributes: attributes) }
     }
 
 }

--- a/Sources/SwiftTUI/Drawing/Rendering/Renderer.swift
+++ b/Sources/SwiftTUI/Drawing/Rendering/Renderer.swift
@@ -126,6 +126,20 @@ class Renderer {
                 output("\u{1b}[23m")
             }
         }
+        if currentAttributes.underlineStyle != new.underlineStyle {
+            if new.underlineStyle != nil {
+                output("\u{1b}[4m")
+            } else {
+                output("\u{1b}[24m")
+            }
+        }
+        if currentAttributes.strikethroughStyle != new.strikethroughStyle {
+            if new.strikethroughStyle != nil {
+                output("\u{1b}[9m")
+            } else {
+                output("\u{1b}[29m")
+            }
+        }
         if self.currentAttributes.inverted != new.inverted {
             if new.inverted == true {
                 output("\u{1b}[7m")

--- a/Sources/SwiftTUI/Drawing/Text+LineStyle.swift
+++ b/Sources/SwiftTUI/Drawing/Text+LineStyle.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+extension Text {
+    public struct LineStyle: Hashable {
+        /// SwiftTUI's alternative to Foundation's `NSUnderlineStyle`.
+        public enum UnderlineStyle {
+            case single
+        }
+
+        public enum Pattern: Hashable {
+            case solid
+        }
+
+        let style: UnderlineStyle
+
+        public init?(underlineStyle: UnderlineStyle?) {
+            guard let underlineStyle = underlineStyle else {
+                return nil
+            }
+            self.style = underlineStyle
+        }
+
+        public init(pattern: Pattern) {
+            switch pattern {
+            case .solid:
+                self.style = .single
+            }
+        }
+    }
+}

--- a/Sources/SwiftTUI/View/Views/Controls/Button.swift
+++ b/Sources/SwiftTUI/View/Views/Controls/Button.swift
@@ -49,9 +49,7 @@ private class ButtonControl: Control {
     override func cell(at position: Position) -> Cell? {
         guard position.line == 0 else { return nil }
         guard position.column < text.count else { return .init(char: " ") }
-        var cell = Cell(char: text[text.index(text.startIndex, offsetBy: position.column)])
-        cell.inverted = isFirstResponder
-        return cell
+        return Cell(char: text[text.index(text.startIndex, offsetBy: position.column)], attributes: AttributeContainer().inverted(isFirstResponder))
     }
 
     override var selectable: Bool { true }

--- a/Sources/SwiftTUI/View/Views/Controls/Color+View.swift
+++ b/Sources/SwiftTUI/View/Views/Controls/Color+View.swift
@@ -26,7 +26,7 @@ private class ColorControl: Control {
     }
 
     override func cell(at position: Position) -> Cell? {
-        Cell(char: " ", backgroundColor: color)
+        Cell(char: " ", attributes: AttributeContainer().backgroundColor(color))
     }
 
 }

--- a/Sources/SwiftTUI/View/Views/Controls/Text.swift
+++ b/Sources/SwiftTUI/View/Views/Controls/Text.swift
@@ -11,6 +11,11 @@ public struct Text: View, Primitive {
         self.textAttributes = Array(repeating: AttributeContainer(), count: text.count)
     }
 
+    public init(_ attributedText: AttributedString) {
+        self.text = String(attributedText.characters)
+        self.textAttributes = Self.charsAttributes(from: attributedText)
+    }
+
     static var size: Int? { 1 }
 
     func buildNode(_ node: Node) {

--- a/Sources/SwiftTUI/View/Views/Controls/Text.swift
+++ b/Sources/SwiftTUI/View/Views/Controls/Text.swift
@@ -5,6 +5,8 @@ public struct Text: View, Primitive {
     let textAttributes: [AttributeContainer]
     @Environment(\.foregroundColor) var foregroundColor: Color
     @Environment(\.font) var font: Font
+    @Environment(\.strikethrough) var strikethrough: Bool
+    @Environment(\.underline) var underline: Bool
 
     public init(_ text: String) {
         self.text = text
@@ -44,12 +46,14 @@ private extension Text {
 
     /// Creates an array by merging _view_ and text attributes.
     func cellsAttributes() -> [AttributeContainer] {
-        var viewAttributes: AttributeContainer = AttributeContainer()
+        var viewAttributes = AttributeContainer()
         viewAttributes.font = font
         viewAttributes.foregroundColor = foregroundColor
+        viewAttributes.strikethroughStyle = LineStyle(underlineStyle: strikethrough ? .single : .none)
+        viewAttributes.underlineStyle = LineStyle(underlineStyle: underline ? .single : .none)
         return textAttributes.map { container in
             var container = container
-            container.merge(viewAttributes, mergePolicy: AttributedString.AttributeMergePolicy.keepCurrent)
+            container.merge(viewAttributes, mergePolicy: .keepCurrent)
             return container
         }
     }

--- a/Sources/SwiftTUI/View/Views/Controls/Text.swift
+++ b/Sources/SwiftTUI/View/Views/Controls/Text.swift
@@ -2,18 +2,20 @@ import Foundation
 
 public struct Text: View, Primitive {
     let text: String
+    let textAttributes: [AttributeContainer]
     @Environment(\.foregroundColor) var foregroundColor: Color
     @Environment(\.font) var font: Font
 
     public init(_ text: String) {
         self.text = text
+        self.textAttributes = Array(repeating: AttributeContainer(), count: text.count)
     }
 
     static var size: Int? { 1 }
 
     func buildNode(_ node: Node) {
         setupEnvironmentProperties(node: node)
-        node.control = TextControl(text: text, color: foregroundColor, font: font)
+        node.control = TextControl(text: text, attributes: cellsAttributes())
     }
     
     func updateNode(_ node: Node) {
@@ -21,20 +23,40 @@ public struct Text: View, Primitive {
         node.nodeBuilder = self
         let control = node.control as! TextControl
         control.text = text
-        control.color = foregroundColor
+        control.attributes = cellsAttributes()
         control.layer.invalidate()
+    }
+}
+
+private extension Text {
+    /// Creates an array containing the attributes of each one of the characters of an attributed string.
+    static func charsAttributes(from attributedString: AttributedString) -> [AttributeContainer] {
+        attributedString.runs.reduce(into: [AttributeContainer]()) { result, run in
+            let containers = Array(repeating: run.attributes, count: attributedString[run.range].characters.count)
+            result.append(contentsOf: containers)
+        }
+    }
+
+    /// Creates an array by merging _view_ and text attributes.
+    func cellsAttributes() -> [AttributeContainer] {
+        var viewAttributes: AttributeContainer = AttributeContainer()
+        viewAttributes.font = font
+        viewAttributes.foregroundColor = foregroundColor
+        return textAttributes.map { container in
+            var container = container
+            container.merge(viewAttributes, mergePolicy: AttributedString.AttributeMergePolicy.keepCurrent)
+            return container
+        }
     }
 }
 
 private class TextControl: Control {
     var text: String
-    var color: Color
-    var font: Font
+    var attributes: [AttributeContainer]
 
-    init(text: String, color: Color, font: Font) {
+    init(text: String, attributes: [AttributeContainer]) {
         self.text = text
-        self.color = color
-        self.font = font
+        self.attributes = attributes
     }
 
     override func size(proposedSize: Size) -> Size {
@@ -44,6 +66,8 @@ private class TextControl: Control {
     override func cell(at position: Position) -> Cell? {
         guard position.line == 0 else { return nil }
         guard position.column < text.count else { return .init(char: " ") }
-        return Cell(char: text[text.index(text.startIndex, offsetBy: position.column)], foregroundColor: color, font: font)
+        let index = text.index(text.startIndex, offsetBy: position.column)
+        let distance = text.distance(from: text.startIndex, to: index)
+        return Cell(char: text[index], attributes: attributes[distance])
     }
 }

--- a/Sources/SwiftTUI/View/Views/Modifiers/Background.swift
+++ b/Sources/SwiftTUI/View/Views/Modifiers/Background.swift
@@ -47,7 +47,7 @@ private class BackgroundControl: Control {
     }
 
     override func cell(at position: Position) -> Cell? {
-        Cell(char: " ", backgroundColor: color)
+        Cell(char: " ", attributes: AttributeContainer().backgroundColor(color))
     }
 
 }

--- a/Sources/SwiftTUI/View/Views/Modifiers/Border.swift
+++ b/Sources/SwiftTUI/View/Views/Modifiers/Border.swift
@@ -80,7 +80,7 @@ private class BorderControl: Control {
         } else if position.column == 0 || position.column == layer.frame.size.width - 1 {
             char = "│"
         }
-        return char.map { Cell(char: $0, foregroundColor: color) }
+        return char.map { Cell(char: $0, attributes: AttributeContainer().foregroundColor(color)) }
     }
 
 }

--- a/Sources/SwiftTUI/View/Views/Modifiers/StrikethroughEnvironmentKey.swift
+++ b/Sources/SwiftTUI/View/Views/Modifiers/StrikethroughEnvironmentKey.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public extension View {
+    func strikethrough(_ isActive: Bool = true) -> some View {
+        environment(\.strikethrough, isActive)
+    }
+}
+
+private struct StrikethroughEnvironmentKey: EnvironmentKey {
+    static var defaultValue: Bool { false }
+}
+
+extension EnvironmentValues {
+    var strikethrough: Bool {
+        get { self[StrikethroughEnvironmentKey.self] }
+        set { self[StrikethroughEnvironmentKey.self] = newValue }
+    }
+}

--- a/Sources/SwiftTUI/View/Views/Modifiers/UnderlineEnvironmentKey.swift
+++ b/Sources/SwiftTUI/View/Views/Modifiers/UnderlineEnvironmentKey.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public extension View {
+    func underline(_ isActive: Bool = true) -> some View {
+        environment(\.underline, isActive)
+    }
+}
+
+private struct UnderlineEnvironmentKey: EnvironmentKey {
+    static var defaultValue: Bool { false }
+}
+
+extension EnvironmentValues {
+    var underline: Bool {
+        get { self[UnderlineEnvironmentKey.self] }
+        set { self[UnderlineEnvironmentKey.self] = newValue }
+    }
+}


### PR DESCRIPTION
I have limited experience with `AttributeContainer`. But it could be a convenient way to move attributes around.

It has decoupled `Cell` from the character's attributes. And `Layer` and `Renderer` implementations seem to benefit from it as well.

At first I just wanted to add `AttributeString` initialiser to `Text`. But then I thought adding `strikethrough` and `underline` was a good way to showcase the changes. This is why I ended up throwing some extra stuff into this branch.

`Text.LineStyle` handling is just outlined.

I added the `UnderlineStyle` enum because `NSUnderlineStyle` is currently not available for Linux.

I think it would make sense to add `byWord` and `patternDash` cases to `UnderlineStyle`. But the changes required would have added too much noise to the `AttributeContainer` proposal.

Let's see if any of this has some value🙂

![image](https://github.com/rensbreur/SwiftTUI/assets/121196946/171e1dc5-c9ed-4da1-83aa-7134a111cd7f)
