### PR TITLE
Fix issue 25

### DIFF
--- a/Sources/SwiftTUI/RunLoop/Application.swift
+++ b/Sources/SwiftTUI/RunLoop/Application.swift
@@ -147,7 +147,17 @@ public class Application {
 
     private func stop() {
         renderer.stop()
+        resetInputMode() // Fix for: https://github.com/rensbreur/SwiftTUI/issues/25
         exit(0)
+    }
+
+    /// Fix for: https://github.com/rensbreur/SwiftTUI/issues/25
+    private func resetInputMode() {
+        // Reset ECHO and ICANON values:
+        var tattr = termios()
+        tcgetattr(STDIN_FILENO, &tattr)
+        tattr.c_lflag |= tcflag_t(ECHO | ICANON)
+        tcsetattr(STDIN_FILENO, TCSAFLUSH, &tattr);
     }
 
 }


### PR DESCRIPTION
Fix for issue https://github.com/rensbreur/SwiftTUI/issues/25 - Can't get cursor back after closing the examples using Ctrl-C or Ctrl-D in SSH session

Resets ECHO and ICANON flags, allowing SwiftTUI to work correctly with `bash` and `csh` shell. Tested with `zsh`, `tcsh`, `bash` and `csh` on Linux. And `zsh` and `bash` on macOS.