### PR TITLE
Allow custom input and output destinations

### DIFF
--- a/Sources/SwiftTUI/Drawing/Size.swift
+++ b/Sources/SwiftTUI/Drawing/Size.swift
@@ -4,6 +4,11 @@ public struct Size: Equatable, CustomStringConvertible {
     public var width: Extended
     public var height: Extended
 
+    public init(width: Extended, height: Extended) {
+        self.width = width
+        self.height = height
+    }
+
     public static var zero: Size { Size(width: 0, height: 0) }
 
     public var description: String { "\(width)x\(height)" }

--- a/Sources/SwiftTUI/RunLoop/Application.swift
+++ b/Sources/SwiftTUI/RunLoop/Application.swift
@@ -47,7 +47,8 @@ public class Application {
         case cocoa
     }
 
-    public func start() {
+    @MainActor
+    public func startInBackground() {
         setInputMode()
         updateWindowSize()
         control.layout(size: window.layer.frame.size)
@@ -66,6 +67,11 @@ public class Application {
         let sigIntSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
         sigIntSource.setEventHandler(qos: .default, flags: [], handler: self.stop)
         sigIntSource.resume()
+    }
+
+    @MainActor
+    public func start() {
+        startInBackground()
 
         switch runLoopType {
         case .dispatch:

--- a/Sources/SwiftTUI/Views/Controls/Button.swift
+++ b/Sources/SwiftTUI/Views/Controls/Button.swift
@@ -48,7 +48,7 @@ public struct Button<Label: View>: View, PrimitiveView {
         }
 
         override func handleEvent(_ char: Character) {
-            if char == "\n" || char == " " {
+            if char == "\n" || char == "\r" || char == " " {
                 action()
             }
         }


### PR DESCRIPTION
This PR should address #13 , allowing us to communicate outside of `stdin` and `stdout`.

- `startInBackground` is added so that this library work with structured concurrency, and doesn't require the start to be top-level. In Structured concurrency, the main thread is already active and usable
- In addition, a new initializer and set of functions are exposed which allow input to come from an external source (SSH server), and output to be emitted in the same fashion.
- I should've put this in a separate PR, but `\r` is sent by the `ssh` client when pressing a button. I've made sure buttons can parse that input

An example implementation: https://github.com/orlandos-nl/Citadel/pull/65/files#diff-81bcbcd2ec23b21cc7b25d541760ca887a9e2819b67b7bbaa939bed4b83ef3df
