### PR TITLE
Add Observation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,5 +22,11 @@ let package = Package(
         .testTarget(
             name: "SwiftTUITests",
             dependencies: ["SwiftTUI"]),
+        .executableTarget(
+            name: "SwiftTUIExample",
+            dependencies: [
+                "SwiftTUI"
+            ]
+        )
     ]
 )

--- a/Sources/SwiftTUI/PropertyWrappers/View+ObservableObject.swift
+++ b/Sources/SwiftTUI/PropertyWrappers/View+ObservableObject.swift
@@ -4,9 +4,13 @@ import Combine
 
 extension View {
     func setupObservedObjectProperties(node: Node) {
+        log("Inside setupObservedObjectProperties")
+        
         for (label, value) in Mirror(reflecting: self).children {
             if let label, let observedObject = value as? AnyObservedObject {
+                log("subscribing to label: \(label)")
                 node.subscriptions[label] = observedObject.subscribe {
+                    log("ObservableObject observed a change. invalidating node...")
                     node.root.application?.invalidateNode(node)
                 }
             }

--- a/Sources/SwiftTUI/PropertyWrappers/View+Observation.swift
+++ b/Sources/SwiftTUI/PropertyWrappers/View+Observation.swift
@@ -1,0 +1,28 @@
+import Observation
+import Foundation
+
+@available(macOS 14.0, *)
+extension View {
+    func setupObservableClassProperties(node: Node) {
+        for (_, value) in Mirror(reflecting: self).children {
+            if let observable = value as? Observation.Observable {
+                startObservation(node: node)
+            }
+        }
+    }
+    
+    func startObservation(node: Node) {
+        log("Starting observation")
+        withObservationTracking {
+            self.body
+        } onChange: {
+            defer {
+                Task { @MainActor in
+                    startObservation(node: node)
+                }
+            }
+            log("Observation observed a change. invalidating node...")
+            node.root.application?.invalidateNode(node)
+        }
+    }
+}

--- a/Sources/SwiftTUI/ViewGraph/ComposedView.swift
+++ b/Sources/SwiftTUI/ViewGraph/ComposedView.swift
@@ -10,10 +10,14 @@ struct ComposedView<I: View>: GenericView {
         #if os(macOS)
         view.setupObservedObjectProperties(node: node)
         #endif
+        if #available(macOS 14.0, *) {
+            view.setupObservableClassProperties(node: node)
+        }
         node.addNode(at: 0, Node(view: view.body.view))
     }
 
     func updateNode(_ node: Node) {
+        log("calling updateNode")
         view.setupStateProperties(node: node)
         view.setupEnvironmentProperties(node: node)
         node.view = self

--- a/Sources/SwiftTUIExample/ExampleApp.swift
+++ b/Sources/SwiftTUIExample/ExampleApp.swift
@@ -1,0 +1,115 @@
+
+import SwiftTUI
+
+@main struct ExampleApp {
+    static func main() {
+        if #available(macOS 14.0, *) {
+            Application(
+                rootView: ExampleView(),
+                runLoopType: .cocoa
+            )
+            .start()
+        } else {
+            // Fallback on earlier versions
+            log("This ExampleApp requires macOS 14.0 or newer")
+        }
+    }
+}
+
+@available(macOS 14.0, *)
+struct ExampleView: View {
+    var body: some View {
+        HStack {
+            ObservationView().border()
+            CombineView().border()
+        }
+    }
+}
+
+// MARK: Observation example
+import Observation
+
+@available(macOS 14.0, *)
+struct ObservationView: View {
+    let vm: CounterViewModel
+    init(vm: CounterViewModel = .init()) {
+        self.vm = vm
+    }
+    
+    var body: some View {
+        VStack {
+            Text("ObservationView").underline()
+            if vm.showCounter {
+                Text("int: \(vm.int)")
+            }
+            VStack {
+                Button("Show/Hide Counter") {
+                    vm.showCounter.toggle()
+                }
+                Button("↑") {
+                    log("Incrementing...")
+                    vm.int += 1
+                    log("Counter is now: \(vm.int)")
+                }
+                Button("↓") {
+                    log("Decrementing...")
+                    vm.int -= 1
+                    log("Counter is now: \(vm.int)")
+                }
+            }
+        }
+    }
+}
+
+@available(macOS 14.0, *)
+@Observable class CounterViewModel {
+    var int: Int
+    var showCounter: Bool
+    
+    init(int: Int = 0, showCounter: Bool = true) {
+        self.int = int
+        self.showCounter = showCounter
+    }
+}
+
+
+
+// MARK: Combine Example
+struct CombineView: View {
+    @ObservedObject var vm: CombineViewModel = CombineViewModel()
+    
+    var body: some View {
+        VStack {
+            Text("CombineView").underline()
+            if vm.showCounter {
+                Text("int: \(vm.int)")
+            }
+            VStack {
+                Button("Show/Hide Counter") {
+                    vm.showCounter.toggle()
+                }
+                Button("↑") {
+                                    log("Incrementing...")
+                    vm.int += 1
+                                    log("Counter is now: \(vm.int)")
+                }
+                Button("↓") {
+                                    log("Decrementing...")
+                    vm.int -= 1
+                                    log("Counter is now: \(vm.int)")
+                }
+            }
+        }
+    }
+}
+
+import Combine
+class CombineViewModel: ObservableObject {
+    @Published var int = 0
+    @Published var showCounter = true
+    
+    init(int: Int = 0, showCounter: Bool = true) {
+        self.int = int
+        self.showCounter = showCounter
+    }
+}


### PR DESCRIPTION
This PR adds support for the language-level [Observation framework](https://developer.apple.com/documentation/observation) and also resolves #42. 

This PR makes no changes to other functionality and does not affect the existing `ObservableObject` infrastructure. 

## Platform Availability
Since `Observation` is available on Windows/Linux/ other platforms, there is now a way to create observable view models on other platforms. 

### Future Opportunities for Backporting
Unfortunately Observation is only available on macOS 14+

The [swift-perception](https://github.com/pointfreeco/swift-perception) library makes it quite easy to backport Observation to iOS 13+, macOS 10.15+ etc. If we were willing to add swift-perception as a dependency, it would be very easy to backport the observation feature. 

## Example
For demonstration purposes, this PR includes a new executable target named "SwiftTUIExample". (You may or may not want to add this to the Examples directory later.)

Simply run `swift run` in the terminal. This will build and run the "SwiftTUIExample" app. This app is a very simple side-by-side comparison of a View implemented with Observation and a View implemented with Combine. 

Also for demonstration purposes I added a few `log()` calls to show exactly when Observation triggers View updates. Run `tail -f /tmp/swift_tui_log` to see the logs. Notice that the `ObservationView` on the left will only invalidate a node (trigger a view update) when the counter is showed. But the `CombineView` on the right will always invalidate a node even when the changed property is not currently affecting the view. 

In other words, the Observation framework has the added benefit that it automatically reduces unnecessary View rerenders. 